### PR TITLE
Search for targets generated by Meson. Allow for trailing whitespace …

### DIFF
--- a/lib/build-ninja.js
+++ b/lib/build-ninja.js
@@ -115,7 +115,7 @@ export function provideBuilder() {
 
 function parseTarget(line) {
   // For some reason, "line" can have trailing whitespace on Windows.
-  const m = /^\s*([-.@/\\\w]+): (\w+)\s?$/.exec(line);
+  const m = /^\s*([-.@/\\\w]+): (\w+)\s*$/.exec(line);
   if (m != null)
     return { name: m[1], type: m[2] };
   return null;

--- a/lib/build-ninja.js
+++ b/lib/build-ninja.js
@@ -114,7 +114,8 @@ export function provideBuilder() {
 }
 
 function parseTarget(line) {
-  const m = /^\s*(\w+): (\w+)$/.exec(line);
+  // For some reason, "line" can have trailing whitespace on Windows.
+  const m = /^\s*([-.@/\\\w]+): (\w+)\s?$/.exec(line);
   if (m != null)
     return { name: m[1], type: m[2] };
   return null;


### PR DESCRIPTION
…in parseTarget.

`Meson` targets in the `ninja` backend use the following characters: `-`, `@`, `.`, and path separators (I included both, even though I only saw `/` in practice).

As-is right now, the whole package doesn't work on Windows because `StreamSplitter` is returning lines with trailing `""`, so the regex fails on all targets without this commit.

I just combined both fixes into one. I recommend a `targetDepth` of 4 or so from my own experience with `meson`.